### PR TITLE
Code examples use up-to-date public interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Drivex](https://hex.pm/packages/drivex) is a Google Drive API Elixir wrapper library. Here is an example:
 
 ```elixir
-iex> GoogleDrive.list_file()
+iex> GoogleDrive.list()
 %{"files" => [%{"id" => "1tDgypK1qrcg0oule4Cxxxxxxxy0L7CwN82G0JxC8",
      "kind" => "drive#file",
      "mimeType" => "application/vnd.google-apps.spreadsheet", "name" => "spreadsheet1"},
@@ -51,7 +51,7 @@ config :goth,
 ```
 mix desp.get
 iex -S mix
-iex> GoogleDrive.list_file
+iex> GoogleDrive.list()
 %{"files" => [%{"id" => "1tDgypK1qrcg0oule4Cxxxxxxxy0L7CwN82G0JxC8",
   "kind" => "drive#file",
   "mimeType" => "application/vnd.google-apps.spreadsheet", "name" => "spreadsheet1"},


### PR DESCRIPTION
As of [63cc0c3](https://github.com/piacere-ex/drivex/commit/63cc0c33ba900863cec6fe13795eff71102b9858), 

+ `GoogleDrive.list_file/0` and 
+ `GoogleDrive.list_file/1` 

became 

+ `GoogleDrive.list/0` and 
+ `GoogleDrive.list/1` 

respectively.

This updates the README to reflect these changes.